### PR TITLE
Implement Task index with navigation and CRUD

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,0 +1,49 @@
+class TasksController < ApplicationController
+  before_action :set_task, only: %i[show edit update destroy]
+
+  def index
+    @tasks = Task.all
+  end
+
+  def show
+  end
+
+  def new
+    @task = Task.new
+  end
+
+  def edit
+  end
+
+  def create
+    @task = Task.new(task_params)
+    if @task.save
+      redirect_to @task, notice: 'Task was successfully created.'
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    if @task.update(task_params)
+      redirect_to @task, notice: 'Task was successfully updated.'
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @task.destroy
+    redirect_to tasks_url, notice: 'Task was successfully destroyed.'
+  end
+
+  private
+
+  def set_task
+    @task = Task.find(params[:id])
+  end
+
+  def task_params
+    params.require(:task).permit(:title, :description, :apply_deadline, :required_number_of_people, :status, :organization_id)
+  end
+end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,3 +1,4 @@
 class Task < ApplicationRecord
   belongs_to :organization
+  has_many :applications, dependent: :destroy
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,6 +23,7 @@
   </head>
 
   <body>
+    <%= render 'shared/navbar' %>
     <%= yield %>
   </body>
 </html>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,0 +1,8 @@
+<nav>
+  <ul style="list-style:none;display:flex;gap:10px;padding:0;">
+    <li><%= link_to 'プロダクト名', root_path %></li>
+    <li><%= link_to 'タスク一覧', tasks_path %></li>
+    <li><%= link_to '応募一覧', '#' %></li>
+    <li><%= link_to 'ログイン', '#' %></li>
+  </ul>
+</nav>

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -1,0 +1,29 @@
+<%= form_with(model: task, local: true) do |f| %>
+  <div>
+    <%= f.label :title, 'タスク名' %><br>
+    <%= f.text_field :title %>
+  </div>
+  <div>
+    <%= f.label :description, '説明' %><br>
+    <%= f.text_area :description %>
+  </div>
+  <div>
+    <%= f.label :apply_deadline, '応募締切' %><br>
+    <%= f.date_field :apply_deadline %>
+  </div>
+  <div>
+    <%= f.label :required_number_of_people, '募集人数' %><br>
+    <%= f.number_field :required_number_of_people %>
+  </div>
+  <div>
+    <%= f.label :status, '募集状況' %><br>
+    <%= f.text_field :status %>
+  </div>
+  <div>
+    <%= f.label :organization_id, 'Organization' %><br>
+    <%= f.number_field :organization_id %>
+  </div>
+  <div>
+    <%= f.submit %>
+  </div>
+<% end %>

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -1,0 +1,7 @@
+<% content_for :title, 'タスク編集' %>
+
+<h1>タスク編集</h1>
+
+<%= render 'form', task: @task %>
+
+<%= link_to '戻る', tasks_path %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,0 +1,50 @@
+<% content_for :title, 'タスク一覧' %>
+
+<h1>タスク一覧</h1>
+
+<div>
+  <%= form_with url: tasks_path, method: :get, local: true do %>
+    <select name="recruitment_status">
+      <option value="">募集状況</option>
+      <option value="open">受付中</option>
+      <option value="closed">終了</option>
+    </select>
+    <select name="application_status">
+      <option value="">応募状況</option>
+      <option value="applied">済</option>
+      <option value="not_applied">未</option>
+    </select>
+    <%= submit_tag '検索' %>
+  <% end %>
+  <%= link_to '新規タスク', new_task_path, style: 'float:right;' %>
+</div>
+
+<table>
+  <thead>
+    <tr>
+      <th>タスク名</th>
+      <th>募集人数</th>
+      <th>募集状況</th>
+      <th>応募締切</th>
+      <th>応募状況</th>
+      <th>応募中人数</th>
+      <th>詳細</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @tasks.each do |task| %>
+      <tr>
+        <td><%= task.title %></td>
+        <td><%= task.required_number_of_people %></td>
+        <td><%= task.status %></td>
+        <td><%= task.apply_deadline %></td>
+        <td><%= task.applications.any? ? '済' : '未' %></td>
+        <td><%= task.applications.count %></td>
+        <td>
+          <%= link_to '閲覧', task_path(task) %> |
+          <%= link_to '編集', edit_task_path(task) %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -1,0 +1,7 @@
+<% content_for :title, '新規タスク' %>
+
+<h1>新規タスク</h1>
+
+<%= render 'form', task: @task %>
+
+<%= link_to '戻る', tasks_path %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,0 +1,27 @@
+<% content_for :title, @task.title %>
+
+<h1><%= @task.title %></h1>
+
+<p><%= @task.description %></p>
+
+<table>
+  <tr>
+    <th>募集人数</th>
+    <td><%= @task.required_number_of_people %></td>
+  </tr>
+  <tr>
+    <th>募集状況</th>
+    <td><%= @task.status %></td>
+  </tr>
+  <tr>
+    <th>応募締切</th>
+    <td><%= @task.apply_deadline %></td>
+  </tr>
+  <tr>
+    <th>応募中人数</th>
+    <td><%= @task.applications.count %></td>
+  </tr>
+</table>
+
+<%= link_to '編集', edit_task_path(@task) %> |
+<%= link_to '一覧に戻る', tasks_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,6 @@ Rails.application.routes.draw do
   # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
   # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
 
-  # Defines the root path route ("/")
-  # root "posts#index"
+  resources :tasks
+  root "tasks#index"
 end


### PR DESCRIPTION
## Summary
- add `TasksController` with full CRUD actions
- add `Task` associations to applications
- add navigation bar in layout
- implement task index table and basic CRUD views
- configure routes for tasks

## Testing
- `bin/rails test` *(fails: `ruby-3.3.6` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6843e6321424832d8d768d6b66556ed2