### PR TITLE
Add status dropdown for Task forms

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,4 +1,6 @@
 class Task < ApplicationRecord
   belongs_to :organization
   has_many :applications, dependent: :destroy
+
+  STATUS_OPTIONS = ["公開待ち", "募集中", "募集終了", "募集停止"].freeze
 end

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -17,7 +17,7 @@
   </div>
   <div>
     <%= f.label :status, '募集状況' %><br>
-    <%= f.text_field :status %>
+    <%= f.select :status, Task::STATUS_OPTIONS, { prompt: '選択してください' } %>
   </div>
   <div>
     <%= f.label :organization_id, 'Organization' %><br>


### PR DESCRIPTION
## Summary
- add `STATUS_OPTIONS` constant to `Task`
- use select field for `status` in task form

## Testing
- `bin/rubocop` *(fails: ruby 3.3.6 not installed)*
- `bin/rails test` *(fails: ruby 3.3.6 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68456515a160832d8351f332b3513f5d