### PR TITLE
Fix task creation

### DIFF
--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -20,10 +20,10 @@
     <%= f.select :status, Task::STATUS_OPTIONS, { prompt: '選択してください' } %>
   </div>
   <div>
-    <%= f.label :organization_id, 'Organization' %><br>
-    <%= f.number_field :organization_id %>
+    <%= f.label :organization_id, '組織' %><br>
+    <%= f.collection_select :organization_id, Organization.all, :id, :name, { prompt: '選択してください' } %>
   </div>
   <div>
-    <%= f.submit %>
+    <%= f.submit '新規作成' %>
   </div>
 <% end %>


### PR DESCRIPTION
## Summary
- fix task form to use Japanese labels and update submit button
- show organization names instead of ID when creating tasks

## Testing
- `bundle exec rails test` *(fails: ruby 3.3.6 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68456a314c2c832d83048f482a32be6c