### PR TITLE
Configure DATABASE_URL for Render and local use

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,4 @@
+# Example environment variables for local development
+# Copy this file to .env and adjust values as needed
+
+DATABASE_URL=postgres://postgres:password@db:5432/myapp_development

--- a/README.md
+++ b/README.md
@@ -75,3 +75,7 @@ https://www.figma.com/board/Tg9Kc1h2uKVBiHViTazKya/RUNTEQ%E5%8D%92%E6%A5%AD%E5%8
 
 ■ER図
 https://dbdiagram.io/d/capstone-exam-68200ff25b2fc4582f0eca1d
+
+## ローカル開発用DATABASE_URL
+Docker Composeで起動する`web`サービスでは`DATABASE_URL`環境変数を利用しています。
+リポジトリには`.env.sample`を用意しているので、コピーして`.env`として使用してください。

--- a/compose.yml
+++ b/compose.yml
@@ -35,6 +35,8 @@ services: # コンテナの定義開始
     environment: # 環境変数の設定
       TZ: Asia/Tokyo # タイムゾーンを日本に設定
       user: "1000:1000" # デプロイのために追加
+      # Rails で使用するデータベース接続情報
+      DATABASE_URL: postgres://postgres:password@db:5432/myapp_development
     ports: # ポート設定
       - "3000:3000" # Rails標準のポート
     depends_on: # 依存関係の設定

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,102 +1,33 @@
-# PostgreSQL. Versions 9.3 and up are supported.
-#
-# Install the pg driver:
-#   gem install pg
-# On macOS with Homebrew:
-#   gem install pg -- --with-pg-config=/usr/local/bin/pg_config
-# On Windows:
-#   gem install pg
-#       Choose the win32 build.
-#       Install PostgreSQL and put its /bin directory on your path.
-#
-# Configure Using Gemfile
-# gem "pg"
-#
+# Database configuration for Rails
+
+# Default settings for all environments
+# Local development uses Docker Compose's `db` service
+# Production expects DATABASE_URL to be provided by the platform
+
 default: &default
   adapter: postgresql
   encoding: unicode
-  # For details on connection pooling, see Rails configuration guide
-  # https://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  host: db
-  #接続ユーザー名
-  username: postgres
-  #接続パスワード（database.yml のパスワードと一致）
-  password: password
+  host: <%= ENV.fetch("DB_HOST", "db") %>
+  username: <%= ENV.fetch("DB_USERNAME", "postgres") %>
+  password: <%= ENV.fetch("DB_PASSWORD", "password") %>
 
+# Development environment
+# Using postgres service provided by docker-compose
 development:
   <<: *default
   database: myapp_development
 
-  # The specified database role being used to connect to PostgreSQL.
-  # To create additional roles in PostgreSQL see `$ createuser --help`.
-  # When left blank, PostgreSQL will use the default role. This is
-  # the same name as the operating system user running Rails.
-  #username: myapp
+# Test environment
+# Same settings as development but separate database name
+# Database will be created automatically when running tests
 
-  # The password associated with the PostgreSQL role (username).
-  #password:
-
-  # Connect on a TCP socket. Omitted by default since the client uses a
-  # domain socket that doesn't need configuration. Windows does not have
-  # domain sockets, so uncomment these lines.
-  #host: localhost
-
-  # The TCP port the server listens on. Defaults to 5432.
-  # If your server runs on a different port number, change accordingly.
-  #port: 5432
-
-  # Schema search path. The server defaults to $user,public
-  #schema_search_path: myapp,sharedapp,public
-
-  # Minimum log levels, in increasing order:
-  #   debug5, debug4, debug3, debug2, debug1,
-  #   log, notice, warning, error, fatal, and panic
-  # Defaults to warning.
-  #min_messages: notice
-
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
 test:
   <<: *default
   database: myapp_test
 
-# As with config/credentials.yml, you never want to store sensitive information,
-# like your database password, in your source code. If your source code is
-# ever seen by anyone, they now have access to your database.
-#
-# Instead, provide the password or a full connection URL as an environment
-# variable when you boot the app. For example:
-#
-#   DATABASE_URL="postgres://myuser:mypass@localhost/somedatabase"
-#
-# If the connection URL is provided in the special DATABASE_URL environment
-# variable, Rails will automatically merge its configuration values on top of
-# the values provided in this file. Alternatively, you can specify a connection
-# URL environment variable explicitly:
-#
-#   production:
-#     url: <%= ENV["MY_APP_DATABASE_URL"] %>
-#
-# Read https://guides.rubyonrails.org/configuring.html#configuring-a-database
-# for a full overview on how database connection configuration can be specified.
-#
+# Production environment
+# Render provides DATABASE_URL which contains the full connection string
 production:
-  primary: &primary_production
-    <<: *default
-    database: myapp_production
-    username: myapp
-    password: <%= ENV["MYAPP_DATABASE_PASSWORD"] %>
-  cache:
-    <<: *primary_production
-    database: myapp_production_cache
-    migrations_paths: db/cache_migrate
-  queue:
-    <<: *primary_production
-    database: myapp_production_queue
-    migrations_paths: db/queue_migrate
-  cable:
-    <<: *primary_production
-    database: myapp_production_cable
-    migrations_paths: db/cable_migrate
+  <<: *default
+  url: <%= ENV["DATABASE_URL"] %>


### PR DESCRIPTION
## Summary
- simplify `config/database.yml` to use DATABASE_URL for production
- set DATABASE_URL for the web service in `compose.yml`
- add `.env.sample` for local setup
- document the new environment variable in README

## Testing
- `bundle exec rake -T` *(fails: ruby 3.3.6 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6847a550eed8832d8429281d8bbf3265