### PR TITLE
Implement organization settings

### DIFF
--- a/app/controllers/organization_settings_controller.rb
+++ b/app/controllers/organization_settings_controller.rb
@@ -1,0 +1,51 @@
+class OrganizationSettingsController < ApplicationController
+  before_action :require_login
+
+  def new
+    redirect_to edit_organization_setting_path and return unless current_user.admin?
+    @organization = Organization.new
+  end
+
+  def create
+    unless current_user.admin?
+      redirect_to edit_organization_setting_path and return
+    end
+    @organization = Organization.new(organization_params)
+    if @organization.save
+      current_user.update(organization: @organization)
+      redirect_to tasks_path, notice: '組織を作成しました。'
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+    redirect_to new_organization_setting_path and return if current_user.admin?
+  end
+
+  def update
+    unless current_user.supporter?
+      redirect_to tasks_path and return
+    end
+    if params[:user].present? && current_user.update(user_organization_params)
+      redirect_to tasks_path, notice: '組織を設定しました。'
+    else
+      flash.now[:alert] = '組織を選択してください'
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def organization_params
+    params.require(:organization).permit(:name)
+  end
+
+  def user_organization_params
+    params.require(:user).permit(:organization_id)
+  end
+
+  def require_login
+    redirect_to login_path, alert: 'ログインしてください' unless user_signed_in?
+  end
+end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,2 +1,6 @@
 class Organization < ApplicationRecord
+  has_many :users
+  has_many :tasks
+
+  validates :name, presence: true, uniqueness: true
 end

--- a/app/views/organization_settings/edit.html.erb
+++ b/app/views/organization_settings/edit.html.erb
@@ -1,0 +1,11 @@
+<h1>組織を選択</h1>
+
+<%= form_with model: current_user, url: organization_setting_path, local: true, method: :patch do |f| %>
+  <div>
+    <%= f.label :organization_id, '組織' %><br>
+    <%= f.collection_select :organization_id, Organization.all, :id, :name, {prompt: '選択してください'} %>
+  </div>
+  <div>
+    <%= f.submit '設定' %>
+  </div>
+<% end %>

--- a/app/views/organization_settings/new.html.erb
+++ b/app/views/organization_settings/new.html.erb
@@ -1,0 +1,11 @@
+<h1>組織を新規作成</h1>
+
+<%= form_with model: @organization, url: organization_setting_path, local: true do |f| %>
+  <div>
+    <%= f.label :name, '組織名' %><br>
+    <%= f.text_field :name %>
+  </div>
+  <div>
+    <%= f.submit '作成' %>
+  </div>
+<% end %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -7,6 +7,11 @@
       <li><%= link_to 'ユーザー登録', main_app.new_user_path %></li>
       <li><%= link_to 'ログイン', login_path %></li>
     <% else %>
+      <% if current_user.admin? %>
+        <li><%= link_to '組織新規作成', new_organization_setting_path %></li>
+      <% elsif current_user.supporter? %>
+        <li><%= link_to '組織設定', edit_organization_setting_path %></li>
+      <% end %>
       <li><%= link_to 'ログアウト', logout_path, method: :delete %></li>
     <% end %>
   </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
 
   resources :tasks
+  resource :organization_setting, only: %i[new create edit update]
   resources :users, only: %i[new create] do
     collection do
       get :complete_registration

--- a/test/integration/organization_settings_test.rb
+++ b/test/integration/organization_settings_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+
+class OrganizationSettingsTest < ActionDispatch::IntegrationTest
+  def setup
+    @org1 = Organization.create!(name: "Org1")
+    @admin = User.create!(name: "Admin", mail_address: "admin@example.com", role: "admin", organization: @org1, password: "password")
+    @org2 = Organization.create!(name: "Org2")
+    @supporter = User.create!(name: "Supporter", mail_address: "supporter@example.com", role: "supporter", organization: @org2, password: "password")
+  end
+
+  test "admin creates organization and assigns to self" do
+    post login_path, params: { session: { mail_address: @admin.mail_address, password: "password" } }
+    get new_organization_setting_path
+    assert_response :success
+
+    assert_difference("Organization.count") do
+      post organization_setting_path, params: { organization: { name: "New Org" } }
+    end
+    assert_redirected_to tasks_path
+    follow_redirect!
+    assert_equal "New Org", @admin.reload.organization.name
+  end
+
+  test "supporter selects existing organization" do
+    org3 = Organization.create!(name: "Other Org")
+
+    post login_path, params: { session: { mail_address: @supporter.mail_address, password: "password" } }
+    get edit_organization_setting_path
+    assert_response :success
+
+    patch organization_setting_path, params: { user: { organization_id: org3.id } }
+    assert_redirected_to tasks_path
+    follow_redirect!
+    assert_equal org3, @supporter.reload.organization
+  end
+end


### PR DESCRIPTION
## Summary
- allow admins to create organizations and assign themself
- allow supporters to select an existing organization
- provide organization settings controller and views
- add links in navbar
- test organization settings behavior

## Testing
- `bundle exec rails test` *(fails: rbenv: version `ruby-3.3.6` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684824557700832d902af020884cb9ef