### PR TITLE
Implement admin replies and supporter responses

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -23,6 +23,9 @@ class ApplicationsController < ApplicationController
 
   def edit
     @task = @application.task
+    if current_user.supporter? && @application.request_status.present?
+      redirect_to application_path(@application) and return
+    end
   end
 
   def update
@@ -35,6 +38,9 @@ class ApplicationsController < ApplicationController
         render :edit, status: :unprocessable_entity
       end
     else
+      if @application.request_status.present?
+        redirect_to application_path(@application) and return
+      end
       if @application.update(supporter_application_params)
         msg = if supporter_application_params[:request_status] == '受諾'
                 '受諾が完了しました。'

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -1,7 +1,9 @@
 class ApplicationsController < ApplicationController
-  before_action :require_supporter
   before_action :set_task_from_params, only: %i[new create]
-  before_action :set_application, only: %i[edit update]
+  before_action :set_application, only: %i[edit update show]
+  before_action :require_supporter, only: %i[new create]
+  before_action :require_owner, only: %i[show]
+  before_action :require_admin_or_owner, only: %i[edit update]
 
   def new
     @application = @task.applications.build
@@ -25,11 +27,32 @@ class ApplicationsController < ApplicationController
 
   def update
     @task = @application.task
-    if @application.update(application_params)
-      redirect_to @task, notice: "更新が完了しました。運営の返信をお待ちください"
+    if current_user.admin?
+      if @application.update(admin_application_params)
+        redirect_to @task, notice: "返信が完了しました。サポーターの返信をお待ちください"
+      else
+        flash.now[:alert] = "返信に失敗しました、お手数ですが再度返信を試みてください"
+        render :edit, status: :unprocessable_entity
+      end
     else
-      render :edit, status: :unprocessable_entity
+      if @application.update(supporter_application_params)
+        msg = if supporter_application_params[:request_status] == '受諾'
+                '受諾が完了しました。'
+              elsif supporter_application_params[:request_status] == '辞退'
+                '辞退が完了しました。'
+              else
+                '更新が完了しました。運営の返信をお待ちください'
+              end
+        redirect_to @task, notice: msg
+      else
+        flash.now[:alert] = '返信に失敗しました、お手数ですが再度返信を試みてください'
+        render :edit, status: :unprocessable_entity
+      end
     end
+  end
+
+  def show
+    @task = @application.task
   end
 
   private
@@ -48,5 +71,24 @@ class ApplicationsController < ApplicationController
 
   def application_params
     params.require(:application).permit(:application_status, :experience, :uptime, :comment_supporter)
+  end
+
+  def supporter_application_params
+    params.require(:application).permit(:application_status, :experience, :uptime, :comment_supporter, :request_status)
+  end
+
+  def admin_application_params
+    params.require(:application).permit(:request_status, :comment_organization)
+  end
+
+  def require_owner
+    unless current_user&.supporter? && @application.supporter == current_user
+      redirect_to tasks_path
+    end
+  end
+
+  def require_admin_or_owner
+    return if current_user&.admin?
+    require_owner
   end
 end

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -32,7 +32,12 @@ class ApplicationsController < ApplicationController
     @task = @application.task
     if current_user.admin?
       if @application.update(admin_application_params)
-        redirect_to @task, notice: "返信が完了しました。サポーターの返信をお待ちください"
+        notice = if @application.request_status == '見送り'
+                   '返信が完了しました。'
+                 else
+                   '返信が完了しました。サポーターの返信をお待ちください'
+                 end
+        redirect_to @task, notice: notice
       else
         flash.now[:alert] = "返信に失敗しました、お手数ですが再度返信を試みてください"
         render :edit, status: :unprocessable_entity

--- a/app/views/applications/_admin_form.html.erb
+++ b/app/views/applications/_admin_form.html.erb
@@ -1,0 +1,41 @@
+<%= form_with(model: application, local: true) do |f| %>
+  <div>
+    <label>応募意向</label><br>
+    <%= application.application_status %>
+  </div>
+  <div>
+    <label>経験有無</label><br>
+    <%= application.experience %>
+  </div>
+  <div>
+    <label>稼働時間</label><br>
+    <%= application.uptime %>
+  </div>
+  <div>
+    <label>サポーターコメント</label><br>
+    <%= simple_format(application.comment_supporter) %>
+  </div>
+  <div>
+    <%= f.label :request_status, '依頼状況' %><br>
+    <% if application.request_status.in?(%w[受諾 辞退]) %>
+      <%= application.request_status %>
+    <% elsif application.application_status == '応募' %>
+      <%= f.select :request_status, ['依頼', '見送り'], include_blank: true %>
+    <% else %>
+      <%= application.request_status.presence || '未返信' %>
+    <% end %>
+  </div>
+  <% unless application.application_status == '取り下げ' %>
+    <div>
+      <%= f.label :comment_organization, '運営コメント' %><br>
+      <% if application.request_status.in?(%w[受諾 辞退]) %>
+        <%= simple_format(application.comment_organization) %>
+      <% else %>
+        <%= f.text_area :comment_organization %>
+      <% end %>
+    </div>
+  <% end %>
+  <% if application.application_status == '応募' && !application.request_status.in?(%w[受諾 辞退]) %>
+    <div><%= f.submit '決定' %></div>
+  <% end %>
+<% end %>

--- a/app/views/applications/edit.html.erb
+++ b/app/views/applications/edit.html.erb
@@ -1,4 +1,10 @@
-<% content_for :title, "応募編集：#{@task.title}" %>
-<h1>応募編集：<%= @task.title %></h1>
-<%= render 'form', application: @application %>
+<% if current_user.admin? %>
+  <% content_for :title, "応募返信：#{@task.title}" %>
+  <h1>応募返信：<%= @task.title %></h1>
+  <%= render 'admin_form', application: @application %>
+<% else %>
+  <% content_for :title, "応募編集：#{@task.title}" %>
+  <h1>応募編集：<%= @task.title %></h1>
+  <%= render 'form', application: @application %>
+<% end %>
 <%= link_to 'タスクに戻る', task_path(@task) %>

--- a/app/views/applications/edit.html.erb
+++ b/app/views/applications/edit.html.erb
@@ -5,6 +5,9 @@
 <% else %>
   <% content_for :title, "応募編集：#{@task.title}" %>
   <h1>応募編集：<%= @task.title %></h1>
+  <% if @application.request_status.nil? %>
+    <p>運営からの返信をお待ちください。</p>
+  <% end %>
   <%= render 'form', application: @application %>
 <% end %>
 <%= link_to 'タスクに戻る', task_path(@task) %>

--- a/app/views/applications/edit.html.erb
+++ b/app/views/applications/edit.html.erb
@@ -1,6 +1,11 @@
 <% if current_user.admin? %>
   <% content_for :title, "応募返信：#{@task.title}" %>
   <h1>応募返信：<%= @task.title %></h1>
+  <% if @application.request_status == '辞退' %>
+    <p>依頼は辞退されました</p>
+  <% elsif @application.application_status == '取り下げ' %>
+    <p>応募は取り下げされました</p>
+  <% end %>
   <%= render 'admin_form', application: @application %>
 <% else %>
   <% content_for :title, "応募編集：#{@task.title}" %>

--- a/app/views/applications/edit.html.erb
+++ b/app/views/applications/edit.html.erb
@@ -4,13 +4,15 @@
   <% if @application.request_status == '辞退' %>
     <p>依頼は辞退されました</p>
   <% elsif @application.application_status == '取り下げ' %>
-    <p>応募は取り下げされました</p>
+    <p>応募は取り下げられました</p>
   <% end %>
   <%= render 'admin_form', application: @application %>
 <% else %>
   <% content_for :title, "応募編集：#{@task.title}" %>
   <h1>応募編集：<%= @task.title %></h1>
-  <% if @application.request_status.nil? %>
+  <% if @application.application_status == '取り下げ' %>
+    <p>応募は取り下げられました</p>
+  <% elsif @application.request_status.nil? %>
     <p>運営からの返信をお待ちください。</p>
   <% end %>
   <%= render 'form', application: @application %>

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -1,0 +1,50 @@
+<% content_for :title, "応募：#{@task.title} #{@application.supporter.name}" %>
+<h1>応募：<%= @task.title %>（<%= @application.supporter.name %>）</h1>
+
+<table>
+  <tr>
+    <th>応募意向</th>
+    <td><%= @application.application_status %></td>
+  </tr>
+  <tr>
+    <th>経験有無</th>
+    <td><%= @application.experience %></td>
+  </tr>
+  <tr>
+    <th>稼働可能時間</th>
+    <td><%= @application.uptime %></td>
+  </tr>
+  <tr>
+    <th>サポーターコメント</th>
+    <td><%= simple_format(@application.comment_supporter) %></td>
+  </tr>
+</table>
+
+<% case @application.request_status %>
+<% when '見送り' %>
+  <p>応募いただき誠にありがとうございました。大変申し訳ございませんが今回はご一緒できませんでした。またの機会にぜひお願いいたします。</p>
+  <%= link_to 'タスクに戻る', task_path(@task) %>
+<% when '受諾' %>
+  <p>受諾いただき誠にありがとうございました。後ほど運営から詳細の連絡がご登録のメールアドレスなどに行われます。</p>
+  <%= link_to 'タスクに戻る', task_path(@task) %>
+<% when '辞退' %>
+  <p>応募いただき誠にありがとうございました。またの機会にぜひお願いいたします。</p>
+  <%= link_to 'タスクに戻る', task_path(@task) %>
+<% when '依頼' %>
+  <div>
+    <label>運営コメント</label><br>
+    <%= simple_format(@application.comment_organization) %>
+  </div>
+  <%= form_with(model: @application, url: application_path(@application), method: :patch, local: true) do |f| %>
+    <%= hidden_field_tag 'application[request_status]', '受諾' %>
+    <%= f.submit '受諾' %>
+  <% end %>
+  <%= form_with(model: @application, url: application_path(@application), method: :patch, local: true) do |f| %>
+    <%= hidden_field_tag 'application[request_status]', '辞退' %>
+    <%= f.submit '辞退' %>
+  <% end %>
+  <%= link_to 'タスクに戻る', task_path(@task) %>
+<% else %>
+  <p>運営からの返信をお待ちください。</p>
+  <%= link_to 'タスクに戻る', task_path(@task) %>
+<% end %>

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -1,6 +1,18 @@
 <% content_for :title, "応募：#{@task.title} #{@application.supporter.name}" %>
 <h1>応募：<%= @task.title %>（<%= @application.supporter.name %>）</h1>
 
+<% message = case @application.request_status
+            when '見送り'
+              '応募いただき誠にありがとうございました。大変申し訳ございませんが今回はご一緒できませんでした。またの機会にぜひお願いいたします。'
+            when '受諾'
+              '受諾いただき誠にありがとうございました。後ほど運営から詳細の連絡がご登録のメールアドレスなどに行われます。'
+            when '辞退'
+              '応募いただき誠にありがとうございました。またの機会にぜひお願いいたします。'
+            end %>
+<% if message %>
+  <p><%= message %></p>
+<% end %>
+
 <table>
   <tr>
     <th>応募意向</th>
@@ -21,14 +33,7 @@
 </table>
 
 <% case @application.request_status %>
-<% when '見送り' %>
-  <p>応募いただき誠にありがとうございました。大変申し訳ございませんが今回はご一緒できませんでした。またの機会にぜひお願いいたします。</p>
-  <%= link_to 'タスクに戻る', task_path(@task) %>
-<% when '受諾' %>
-  <p>受諾いただき誠にありがとうございました。後ほど運営から詳細の連絡がご登録のメールアドレスなどに行われます。</p>
-  <%= link_to 'タスクに戻る', task_path(@task) %>
-<% when '辞退' %>
-  <p>応募いただき誠にありがとうございました。またの機会にぜひお願いいたします。</p>
+<% when '見送り', '受諾', '辞退' %>
   <%= link_to 'タスクに戻る', task_path(@task) %>
 <% when '依頼' %>
   <div>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -59,7 +59,11 @@
   |
   <% application = @task.applications.find_by(supporter: current_user) %>
   <% if application %>
-    <%= link_to '応募内容を見る', application_path(application) %>
+    <% if application.request_status.nil? %>
+      <%= link_to '応募内容を編集', edit_application_path(application) %>
+    <% else %>
+      <%= link_to '応募内容を見る', application_path(application) %>
+    <% end %>
   <% else %>
     <%= link_to '応募する', new_application_path(task_id: @task.id) %>
   <% end %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -24,6 +24,34 @@
 </table>
 
 <% if current_user&.admin? %>
+  <h2>応募一覧</h2>
+  <table>
+    <thead>
+      <tr>
+        <th>サポーター名</th>
+        <th>応募状況</th>
+        <th>運営依頼状況</th>
+        <th>経験有無</th>
+        <th>稼働可能時間</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @task.applications.each do |app| %>
+        <tr>
+          <td><%= app.supporter.name %></td>
+          <td><%= app.application_status %></td>
+          <td><%= app.request_status.presence || '未返信' %></td>
+          <td><%= app.experience %></td>
+          <td><%= app.uptime %></td>
+          <td><%= link_to '返信', edit_application_path(app) %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>
+
+<% if current_user&.admin? %>
   <%= link_to '編集', edit_task_path(@task) %> |
 <% end %>
 <%= link_to '一覧に戻る', tasks_path %>
@@ -31,7 +59,7 @@
   |
   <% application = @task.applications.find_by(supporter: current_user) %>
   <% if application %>
-    <%= link_to '応募内容を編集', edit_application_path(application) %>
+    <%= link_to '応募内容を見る', application_path(application) %>
   <% else %>
     <%= link_to '応募する', new_application_path(task_id: @task.id) %>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
   # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
 
   resources :tasks
-  resources :applications, only: %i[new create edit update]
+  resources :applications, only: %i[new create edit update show]
   resource :organization_setting, only: %i[new create edit update]
   resources :users, only: %i[new create] do
     collection do


### PR DESCRIPTION
## Summary
- list applications on task detail for admins
- allow admins to reply to applications and supporters to confirm
- show request statuses and reply controls for supporters
- hide organization comment when application withdrawn
- link supporter application access from task details to the result page

## Testing
- `./install_and_test.sh` *(fails: 403 Forbidden apt repositories)*

------
https://chatgpt.com/codex/tasks/task_e_684aa5b5c5cc832d949a533397449da2