### PR TITLE
Implement task filters and add archive status

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,7 +2,12 @@ class TasksController < ApplicationController
   before_action :set_task, only: %i[show edit update destroy]
 
   def index
-    @tasks = Task.all
+    if user_signed_in?
+      @tasks = Task.where(organization_id: current_user.organization_id)
+      @tasks = @tasks.where(status: %w[募集中 募集終了]) if current_user.supporter?
+    else
+      @tasks = Task.all
+    end
   end
 
   def show

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -15,6 +15,7 @@ class TasksController < ApplicationController
 
   def new
     @task = Task.new
+    @task.organization = current_user.organization if current_user&.admin?
   end
 
   def edit
@@ -22,6 +23,7 @@ class TasksController < ApplicationController
 
   def create
     @task = Task.new(task_params)
+    @task.organization = current_user.organization if current_user&.admin?
     if @task.save
       redirect_to @task, notice: "Task was successfully created."
     else
@@ -49,6 +51,6 @@ class TasksController < ApplicationController
   end
 
   def task_params
-    params.require(:task).permit(:title, :description, :apply_deadline, :required_number_of_people, :status, :organization_id)
+    params.require(:task).permit(:title, :description, :apply_deadline, :required_number_of_people, :status)
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -2,5 +2,5 @@ class Task < ApplicationRecord
   belongs_to :organization
   has_many :applications, dependent: :destroy
 
-  STATUS_OPTIONS = [ "公開待ち", "募集中", "募集終了", "募集停止" ].freeze
+  STATUS_OPTIONS = [ "公開待ち", "募集中", "募集終了", "募集停止", "アーカイブ" ].freeze
 end

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -20,10 +20,6 @@
     <%= f.select :status, Task::STATUS_OPTIONS, { prompt: '選択してください' } %>
   </div>
   <div>
-    <%= f.label :organization_id, '組織' %><br>
-    <%= f.collection_select :organization_id, Organization.all, :id, :name, { prompt: '選択してください' } %>
-  </div>
-  <div>
     <%= f.submit task.new_record? ? '新規作成' : '更新' %>
   </div>
 <% end %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -18,6 +18,10 @@
     <td><%= @task.apply_deadline %></td>
   </tr>
   <tr>
+    <th>組織</th>
+    <td><%= @task.organization.name %></td>
+  </tr>
+  <tr>
     <th>応募中人数</th>
     <td><%= @task.applications.count %></td>
   </tr>


### PR DESCRIPTION
## Summary
- add `アーカイブ` to task status choices
- filter tasks list by current user's organization
- restrict supporter task list to '募集中' and '募集終了'

## Testing
- `bundle exec rails test` *(fails: rbenv: version `ruby-3.3.6` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684ac4ae5fe4832d95f56ac5c6832541