### PR TITLE
Fix production email configuration

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -4,3 +4,13 @@
 DATABASE_URL=postgres://postgres:password@db:5432/myapp_development
 # Set to true only when you want to seed the database automatically
 #RUN_SEEDS=true
+
+# Outgoing email configuration. These settings are used by Action Mailer in
+# production as well as in the Docker Compose environment when needed.
+SMTP_ADDRESS=smtp.sendgrid.net
+SMTP_PORT=587
+SMTP_USERNAME=apikey
+SMTP_PASSWORD=your_sendgrid_api_key
+SMTP_DOMAIN=gmail.com
+MAIL_FROM=example@example.com
+MAILER_HOST=localhost

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,6 +1,6 @@
 class ApplicationMailer < ActionMailer::Base
   # The default sender address is configured via the MAIL_FROM environment
   # variable so that it can be shared across different deployment environments.
-  default from: ENV.fetch("MAIL_FROM", "from@example.com")
+  default from: ENV["MAIL_FROM"] || "from@example.com"
   layout "mailer"
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,6 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: "from@example.com"
+  # The default sender address is configured via the MAIL_FROM environment
+  # variable so that it can be shared across different deployment environments.
+  default from: ENV.fetch("MAIL_FROM", "from@example.com")
   layout "mailer"
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -38,7 +38,7 @@ Rails.application.configure do
   config.logger   = ActiveSupport::TaggedLogging.logger(STDOUT)
 
   # Change to "debug" to log everything (including potentially personally-identifiable information!)
-  config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
+  config.log_level = ENV["RAILS_LOG_LEVEL"] || "info"
 
   # Prevent health checks from clogging up the logs.
   config.silence_healthcheck_path = "/up"
@@ -58,15 +58,17 @@ Rails.application.configure do
   # config.action_mailer.raise_delivery_errors = false
 
   # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: ENV.fetch("MAILER_HOST", "example.com") }
+  config.action_mailer.default_url_options = {
+    host: ENV["MAILER_HOST"] || "example.com"
+  }
 
   # Use SMTP for email delivery in production. Credentials are provided via
   # environment variables so that both Docker Compose and Render deployments can
   # share the same configuration mechanism.
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
-    address: ENV.fetch("SMTP_ADDRESS", "smtp.example.com"),
-    port: ENV.fetch("SMTP_PORT", 587).to_i,
+    address: ENV["SMTP_ADDRESS"] || "smtp.example.com",
+    port: (ENV["SMTP_PORT"] || 587).to_i,
     user_name: ENV["SMTP_USERNAME"],
     password: ENV["SMTP_PASSWORD"],
     domain: ENV["SMTP_DOMAIN"],
@@ -75,7 +77,9 @@ Rails.application.configure do
   }
 
   # Default "from" address for outgoing emails.
-  config.action_mailer.default_options = { from: ENV.fetch("MAIL_FROM", "from@example.com") }
+  config.action_mailer.default_options = {
+    from: ENV["MAIL_FROM"] || "from@example.com"
+  }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -58,16 +58,24 @@ Rails.application.configure do
   # config.action_mailer.raise_delivery_errors = false
 
   # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: "example.com" }
+  config.action_mailer.default_url_options = { host: ENV.fetch("MAILER_HOST", "example.com") }
 
-  # Specify outgoing SMTP server. Remember to add smtp/* credentials via rails credentials:edit.
-  # config.action_mailer.smtp_settings = {
-  #   user_name: Rails.application.credentials.dig(:smtp, :user_name),
-  #   password: Rails.application.credentials.dig(:smtp, :password),
-  #   address: "smtp.example.com",
-  #   port: 587,
-  #   authentication: :plain
-  # }
+  # Use SMTP for email delivery in production. Credentials are provided via
+  # environment variables so that both Docker Compose and Render deployments can
+  # share the same configuration mechanism.
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address: ENV.fetch("SMTP_ADDRESS", "smtp.example.com"),
+    port: ENV.fetch("SMTP_PORT", 587).to_i,
+    user_name: ENV["SMTP_USERNAME"],
+    password: ENV["SMTP_PASSWORD"],
+    domain: ENV["SMTP_DOMAIN"],
+    authentication: :plain,
+    enable_starttls_auto: true
+  }
+
+  # Default "from" address for outgoing emails.
+  config.action_mailer.default_options = { from: ENV.fetch("MAIL_FROM", "from@example.com") }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).


### PR DESCRIPTION
## Summary
- configure Action Mailer SMTP settings in production
- read default email sender from `MAIL_FROM`
- document required environment variables in `.env.sample`

## Testing
- `./install_and_test.sh` *(fails: apt repository access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684fc2e49044832db4022cb00bb982bc